### PR TITLE
Updated to use assets helper. Added page.hbs

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -10,7 +10,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-    <title>{{settings.title}}</title>
+    <title>{{@blog.title}}</title>
 
     <meta name="description" content="{{@blog.description}}">
 
@@ -23,20 +23,20 @@
     <link rel="alternate" type="application/rss+xml" title="{{@blog.title}} » Feed" href="{{@blog.url}}/rss">
 
     <!-- Add Modernizr for better IE8 Support -->
-    <script type="text/javascript" src="{{@blog.url}}/assets/js/libs/modernizr.custom.min.js"></script>
+    <script type="text/javascript" src="{{asset '/js/libs/modernizr.custom.min.js'}}"></script>
 
     <!-- Include the main stylesheet-->
-    <link rel="stylesheet" id="linen-stylesheet-css" href="{{@blog.url}}/assets/css/style.css" type="text/css" media="all">
+    <link rel="stylesheet" id="linen-stylesheet-css" href="{{asset 'css/style.css'}}" type="text/css" media="all" />
 
     <!--[if lt IE 9]>
-    <link rel='stylesheet' id='linen-ie-only-css'  href='{{@blog.url}}/assets/css/ie.css' type='text/css' media='all' />
+    <link rel='stylesheet' id='linen-ie-only-css'  href="{{asset 'css/ie.css'}}" type='text/css' media='all' />
     <![endif]-->
 
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}
 
     <!-- Include custom CSS -->
-    <link rel="stylesheet" id="custom-stylesheet-css" href="{{@blog.url}}/assets/css/custom.css" type="text/css" media="all">
+    <link rel="stylesheet" id="custom-stylesheet-css" href="{{asset 'css/custom.css'}}" type="text/css" media="all">
 </head>
 
 
@@ -78,7 +78,7 @@
     {{ghost_foot}}
 
     <!-- Custom Scripts -->
-    <script type="text/javascript" src="{{@blog.url}}/assets/js/scripts.js"></script>
+    <script type="text/javascript" src="{{asset '/js/scripts.js'}}"></script>
 
 </body>
 </html>

--- a/page.hbs
+++ b/page.hbs
@@ -1,0 +1,12 @@
+{{!< default}}
+
+{{!
+    This is the same as the page template, but without comments.
+    Any post marked as a 'static page' in Ghost will use this template.
+}}
+
+{{#post}}
+
+    {{> full-post}}
+
+{{/post}}

--- a/partials/full-post.hbs
+++ b/partials/full-post.hbs
@@ -5,7 +5,7 @@
     <header class="article-header">
 
         <h1 class="h2">
-            <a href="{{@blog.url}}/{{slug}}" rel="bookmark" title="{{title}}">{{title}}</a>
+            <a href="{{url}}" rel="bookmark" title="{{title}}">{{title}}</a>
         </h1>
 
         <p class="byline vcard">
@@ -25,26 +25,12 @@
                 <span class="amp">&amp;</span>
                 filed under
                 {{#each tags}}
-                    <!-- Tag Links are not quite ready yet.
-                           <a href="/tags/{{this.name}}"
-                           class="tag-label"
-                           title="View all posts in {{this.name}}"
-                           rel="category">{{this.name}}</a>
-                           -->
-                    {{! Use the span below to display tags as plain text until tag links are ready }}
                     <span class="tag-label">{{this.name}}</span>
                 {{/each}}
 
             {{/if}}
         </p>
 
-        {{! Featured images are not yet implemented in Ghost.
-            But when they are, this will be awesome. }}
-        {{#if image}}
-            <figure class="featured-image">
-                <img src="/content/images/{{image}}" class="attachment-post-thumbnail" alt="">
-            </figure>
-        {{/if}}
     </header> <!-- end article header -->
 
     <section class="entry-content clearfix">
@@ -57,12 +43,6 @@
                 <span class="tags-title">
                     Tags:
                     {{#each tags}}
-                        <!-- Tag Links are not quite ready yet.
-                           <a href="/tags/{{this.name}}"
-                           class="tag-label"
-                           title="View all posts in {{this.name}}"
-                           rel="category">{{this.name}}</a>
-                           -->
                         {{! Use the span below to display tags as plain text until tag links are ready }}
                         <span class="tag-label">{{this.name}}</span>
                     {{/each}}

--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -6,6 +6,6 @@
     <ul>
         <li><a href="{{@blog.url}}">Home</a></li>
         <li><a href="">Contact</a></li>
-        <li><a href="">About Me</a></li>
+        <li><a href="{{@blog.url}}/about-me">About Me</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
{{assets}} helper now used to load css and js files. (Breaks compatibility with Ghost 0.3.3)
Added a page.hbs file for static page templating.
Minor tweaks to some Handlebars markup.
Removed unnecessary comments.
